### PR TITLE
docs: fix typo and grammar in hot reload sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The project is fully dockerized 🐳, if we want to start the app in **developme
 docker-compose up -d my-service-dev
 ```
 
-This development mode with work with **hot-reload** and exposing a **debug port**, the `9229`, so later we can connect from our editor to it.
+This development mode will work with **hot-reload** and expose a **debug port**, port `9229`, so later we can connect to it from our editor.
 
 Now, you should be able to start debugging configuring using your IDE. For example, if you are using vscode, you can create a `.vscode/launch.json` file with the following configuration:
 


### PR DESCRIPTION
## Proposed changes

After carefully reading the documentation of the template, I noticed a typo that repeated `with` a couple of times, and while correcting it, I also changed a few words for better grammar.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None
